### PR TITLE
GET/POST students/id/enrollments/

### DIFF
--- a/server/appbackend/api.py
+++ b/server/appbackend/api.py
@@ -371,6 +371,9 @@ class StudentEnrollmentsApi(generics.ListCreateAPIView):
         class_group = ClassGroup.objects.get(pk=request.data.get("class_group_id", ""))
         enrollment_status = EnrollmentStatus(request.data.get("enrollment_status", ""))
         active = True if enrollment_status is EnrollmentStatus.ACCEPTED else False
+        if Enrollment.objects.filter(student=student, class_group=class_group)[:1].get():
+            raise GenericException(code=status.HTTP_400_BAD_REQUEST,
+                                   detail="'{}' is already enrolled in '{}'".format(student.first_name, class_group))
         enrollment = Enrollment.objects.create(student=student, class_group=class_group,
                                                graduated=False, finalGrade=None, active=active,
                                                status=enrollment_status)

--- a/server/appbackend/api.py
+++ b/server/appbackend/api.py
@@ -370,9 +370,6 @@ class StudentEnrollmentsApi(generics.ListCreateAPIView):
         EnrollmentRequestSerializer(data=request.data).is_valid(raise_exception=True)
         class_group = ClassGroup.objects.get(pk=request.data.get("class_group_id", ""))
         enrollment_status = EnrollmentStatus(request.data.get("enrollment_status", ""))
-            # raise GenericException(code=status.HTTP_400_BAD_REQUEST,
-            #                        detail="'{}' is not a valid enrollment status value"
-            #                        .format(enrollment_status))
         active = True if enrollment_status is EnrollmentStatus.ACCEPTED else False
         enrollment = Enrollment.objects.create(student=student, class_group=class_group,
                                                graduated=False, finalGrade=None, active=active,

--- a/server/appbackend/serializers.py
+++ b/server/appbackend/serializers.py
@@ -85,6 +85,20 @@ class EnrollmentSerializer(serializers.ModelSerializer):
         # fields = ('id', 'active', 'status', 'finalGrade', 'graduated')
 
 
+class StudentEnrollmentSerializer(serializers.ModelSerializer):
+    status = serializers.CharField(source='status.name')
+    class_group = ClassGroupSerializer()
+
+    class Meta:
+        model = Enrollment
+        fields = ('id', 'active', 'status', 'class_group', 'finalGrade', 'graduated')
+
+
+class EnrollmentRequestSerializer(serializers.Serializer):
+    class_group_id = serializers.IntegerField()
+    enrollment_status = serializers.CharField()
+
+
 class LessonSerializer(serializers.ModelSerializer):
     class_group = ClassGroupSerializer(read_only=True)
 

--- a/server/appbackend/urls.py
+++ b/server/appbackend/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path('register/', RegisterApi.as_view(), name='register-user'),
     path('register/phone/', RegisterByPhoneApi.as_view(), name='register-user-by-phone'),
     path('login/collaborator/', AuthenticateCollaboratorApi.as_view(), name='authenticate-collaborator'),
+    path('students/<int:pk>/enrollments/', StudentEnrollmentsApi.as_view(), name='see-enrolled-classes')
 ]
 
 


### PR DESCRIPTION
Implements two endpoints in the same path: the GET verb will return all enrollments for that student, and the POST one will create a new enrollment, passing class_group_id and enrollment_status as request body parameters.

**Depends on exception handling PR**